### PR TITLE
Updated to work with 7.x.x+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Apache License 2.0
+
+Copyright 2016 Mark Donnellon
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Cordova Plugin for Configuration from Android for Work
 
 ## How to Use
-Create an XML file at <project root>/resources/android/res/xml/app_restrictions.xml which describes the restrictions you want to make available in your app. See the XML definition [here](https://developer.android.com/work/managed-configurations.html).
+Create an XML file at <project root>/resources/android/app_restrictions.xml which describes the restrictions you want to make available in your app. See the XML definition [here](https://developer.android.com/work/managed-configurations.html).
 
 NOTE: This plugin does not yet come with a way to create resource strings for the description attribute and use of a string resource for the description attribute is compulsory if used. So, you can not yet use the description attribute unless you figure out your own way of adding entries to platform/android/res/xml/strings.xml for you to reference.
 
 This file (only) is automatically copied into the corresponding directory under platform after a Cordova prepare.
-If you want to keep the file elsewhere, ensure app_restrictions.xml is copied to platform/android/res/xml/ or at least exists before attempting to compile. platform/android/res/xml/app_restrictions.xml may be deleted when preparing.
+If you want to keep the file elsewhere, ensure app_restrictions.xml is copied to platform/android/app/src/main/res/xml/ or at least exists before attempting to compile. platform/android/app/src/main/res/xml/app_restrictions.xml may be deleted when preparing.
 This plugin will automatically add the required reference to app_restrictions.xml in AndroidManifest.xml.
 
 In your Cordova JS you can use the below functions to get your application restrictions.

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 
 	<!--
 		copies files from one place to another within our project
-		e.g. the app_restrictions.xml file mentioned below goes into platform/android/res/xml/
+		e.g. the app_restrictions.xml file mentioned below goes into platform/android/app/src/main/res/xml/
 	-->
 	<hook type="after_prepare" src="scripts/copy_files.js" />
 
@@ -32,13 +32,9 @@
 			</feature>
 		</config-file>
 
-
-
-
 		<config-file target="AndroidManifest.xml" parent="/manifest/application/">
 			<meta-data android:name="android.content.APP_RESTRICTIONS" android:resource="@xml/app_restrictions" />
 		</config-file>
-
 
 		<source-file src="src/android/AndroidMDM.java" target-dir="src/au/net/isw/androidmdm/"/>
 	</platform>

--- a/scripts/copy_files.js
+++ b/scripts/copy_files.js
@@ -21,7 +21,7 @@
 // on each developer's box.
 module.exports = function(context){
   var filestocopy = [{
-      "resources/android/res/xml/app_restrictions.xml" : "platforms/android/res/xml/app_restrictions.xml"
+      "resources/android/app_restrictions.xml" : "platforms/android/app/src/main/res/xml/app_restrictions.xml"
   } ];
 
   // no need to configure below

--- a/src/android/AndroidMDM.java
+++ b/src/android/AndroidMDM.java
@@ -75,7 +75,6 @@ public class AndroidMDM extends CordovaPlugin{
     }
     //Check for changes to restrictions
 
-
     /**
      * Get app restrictions as set by Device Policy Controller(DPC)/Enterprise Mobility Management (EMM) provider
      * If a value is not specified by DCP/EMM, it will not appear in returned JSON
@@ -83,8 +82,6 @@ public class AndroidMDM extends CordovaPlugin{
      * Note:
      * The managed configurations Bundle contains one item for every configuration that has been *explicitly* set by a managed configurations provider.
      * However, you cannot assume that a configuration will be present in the bundle just because you defined a default value in the managed configurations XML file.
-     *
-     *
      */
     private JSONObject getAppRestrictions(){
         if(DEBUG)Log.v(TAG, "getAppRestrictions start");
@@ -146,8 +143,6 @@ public class AndroidMDM extends CordovaPlugin{
 
     /**
      * Get restrictions from restrictions configuration set in AndroidManifest.
-     *
-     *
      * @return
      * @author mdonnellon
      */
@@ -280,6 +275,4 @@ public class AndroidMDM extends CordovaPlugin{
     @Override
     public void onDestroy() {
     }
-
-
 }

--- a/www/androidmdm.js
+++ b/www/androidmdm.js
@@ -1,7 +1,4 @@
 /*global cordova, module, console*/
-
-
-
 module.exports = {
     addRestrictionListener: function (callback) {
         "use strict";


### PR DESCRIPTION
Since cordova-android has changed the structure for android projects starting in 7.0.0, the location that the app_restrictions.xml is being copied to is incorrect. I have updated the copy location, and also updated where it is copied from: 

'/resources/android/res/xml/' to '/resources/android/'

This was done since having a single folder at the root as '/resources/android/app/src/main/res/xml' would be rather pointless since it is only the one file being copied.

Also added license file for the license specified in package.json.